### PR TITLE
Fix saving of TiddlyWikiClassic

### DIFF
--- a/src/electron.js
+++ b/src/electron.js
@@ -30,9 +30,9 @@ app.on('ready', function() {
 		width: 1280, 
 		height: 720,
 		webPreferences: {
-			nodeIntegration: false
+			nodeIntegration: true,
+			preload: path.join( __dirname, 'preload-tw5.js')
 		},
-		preload: path.join( __dirname, 'preload-tw5.js')
 	});
 
 	mainWindow.loadURL('file:///' + file);

--- a/src/inject.js
+++ b/src/inject.js
@@ -8,21 +8,9 @@ The JavaScript in this file is injected into each TiddlyWiki page that loads
 	Returns true if successful, false if failed, null if not available
 	*/
 	var injectedSaveFile = function(path,content) {
-		// Find the message box element
-		var messageBox = document.getElementById("tiddlyfox-message-box");
-		if(messageBox) {
-			// Create the message element and put it in the message box
-			var message = document.createElement("div");
-			message.setAttribute("data-tiddlyfox-path",path);
-			message.setAttribute("data-tiddlyfox-content",content);
-			messageBox.appendChild(message);
-			// Create and dispatch the custom event to the extension
-			var event = document.createEvent("Events");
-			event.initEvent("tiddlyfox-save-file",true,false);
-			message.dispatchEvent(event);
-			return true;
-		}
-		return false;
+		const fs = require("fs");
+		fs.writeFileSync(path,content);
+		return true;
 	};
 
 	/*


### PR DESCRIPTION
Saving for TiddlyWikiClassic. Should not break anything with TW5, but I haven't had a chance to confirm that.

- `nodeIntegration=true` to support `require()`
- `preload` attribute must be within `webPreferences`
- Removed delegation of twc saving to non-existent TiddlyFox plugin and use simple `fs.writeFileSync()` instead 

Addresses https://github.com/Arlen22/TiddlyWiki-Electron/issues/1
